### PR TITLE
More fix cursor for duplicate header

### DIFF
--- a/papaparse.js
+++ b/papaparse.js
@@ -1463,7 +1463,7 @@ License: MIT
 
 			// Establish starting state
 			cursor = 0;
-			var data = [], errors = [], row = [], lastCursor = 0;
+			var data = [], errors = [], row = [], lastCursor = 0, inputExpansion = 0;
 
 			if (!input)
 				return returnable();
@@ -1508,6 +1508,10 @@ License: MIT
 				if (duplicateHeaders) {
 					var editedInput = input.split(newline);
 					editedInput[0] = Array.from(headerMap).join(delim);
+					// If we expanded the input due to duplicate headers then reduce cursor
+					// by the amount we expanded the input.
+					// This is needed for keeping leftover aggregate in parseChunk.
+					inputExpansion = editedInput[0].length - firstLine.length;
 					input = editedInput.join(newline);
 				}
 			}
@@ -1517,12 +1521,7 @@ License: MIT
 				for (var i = 0; i < rows.length; i++)
 				{
 					row = rows[i];
-					// use firstline as row length may be changed due to duplicated headers
-					if (i === 0 && firstLine !== undefined) {
-						cursor += firstLine.length;
-					}else{
-						cursor += row.length;
-					}
+					cursor += row.length;
 					if (i !== rows.length - 1)
 						cursor += newline.length;
 					else if (ignoreLastRow)
@@ -1724,7 +1723,7 @@ License: MIT
 			function pushRow(row)
 			{
 				data.push(row);
-				lastCursor = cursor;
+				lastCursor = cursor - inputExpansion;
 			}
 
 			/**

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -191,6 +191,20 @@ describe('PapaParse', function() {
 		});
 	});
 
+	it('Handles quote at EOF when headers are modified', function(done) {
+		var data = [];
+		Papa.parse('field1,field1,field3\na,b,c\nd,e,"f"', {
+			header: true,
+			step: function(results) {
+				data.push(results.data);
+			},
+			complete: function() {
+				assert.deepEqual(data, [{ field1: 'a', field1_1: 'b', field3: 'c' },{ field1: 'd', field1_1: 'e', field3: 'f' }]);
+				done();
+			}
+		});
+	});
+
 	it('piped streaming CSV should be correctly parsed when header is true', function(done) {
 		var data = [];
 		var readStream = fs.createReadStream(__dirname + '/sample-header.csv', 'utf8');

--- a/tests/node-tests.js
+++ b/tests/node-tests.js
@@ -164,6 +164,32 @@ describe('PapaParse', function() {
 		});
 	});
 
+	it('Checks cursor when file is large and has duplicate headers', function(done) {
+		this.timeout(30000);
+		var stepped = 0;
+		var startsWithEtiamOrLorem = true;
+		Papa.parse(fs.createReadStream(__dirname + '/verylong-sample.csv'), {
+			header: true,
+			transformHeader: function(headerName) {
+				return headerName === 'meaning of life' ? 'placeholder' : headerName;
+			},
+			step: function(results, parser) {
+				stepped++;
+				if (results)
+				{
+					if (stepped > 1) {
+						const startsWithEtiam = results.data && results.data.placeholder && results.data.placeholder.startsWith("Etiam");
+						const startsWithLorem = results.data && results.data.placeholder && results.data.placeholder.startsWith("Lorem");
+						startsWithEtiamOrLorem = startsWithEtiamOrLorem && (startsWithEtiam || startsWithLorem);
+					}
+				}
+			},
+			complete: function() {
+				assert(startsWithEtiamOrLorem);
+				done();
+			}
+		});
+	});
 
 	it('piped streaming CSV should be correctly parsed when header is true', function(done) {
 		var data = [];


### PR DESCRIPTION
Papaparse's parse method modifies in the input string when headers are modified and/or duplicated. This changes the overall length of the input.
This change in length needs to be accounted for in the adjustment of lastCursor in pushRow. This is so that the outer parseChunk function can properly account for how much of the chunk is leftover and needs to be kept for prefixing onto the next chunk.

There was a previous [attempt](https://github.com/mholt/PapaParse/pull/997) to fix this [issue](https://github.com/mholt/PapaParse/issues/994), but it only worked for the fast parse path. This fix works for both fast parsing and not-fast.

The added test correctly fails without the fix.

I've also included a bug fix for inputLen, which is needed to correctly handle a file that end with a quote and has modified headers or duplicate headers. I'll add a test to prove this works too.